### PR TITLE
Show libsodium use

### DIFF
--- a/src/curvezmq_selftest.c
+++ b/src/curvezmq_selftest.c
@@ -33,7 +33,11 @@ int main (int argc, char *argv [])
     else
         verbose = false;
 
-    printf ("Running CurveZMQ self tests...\n");
+	#if defined (HAVE_LIBSODIUM)
+    printf ("Running CurveZMQ self tests with libsudium...\n");
+	#else
+    printf ("Running CurveZMQ self tests without libsodium...\n");
+	#endif
 
     curvezmq_codec_test (verbose);
     curvezmq_keypair_test (verbose);


### PR DESCRIPTION
When curvezmq selftest is used, it is important to know easily if it has been built with libsodium or not. This modification uses the HAVE_LIBSODIUM environment variable set by the autotools when it has detected libsodium and passed tests on it in order to use it.
