### PR TITLE
Fixed segfault in curve_selftest function curve_server

### DIFF
--- a/src/curve_server.c
+++ b/src/curve_server.c
@@ -611,7 +611,7 @@ client_task (void *args)
     bool verbose = *((bool *) args);
     
     char filename [256];
-    printf (filename, TESTDIR "/client-%07d.cert", randof (10000000));
+    snprintf (filename, 255, TESTDIR "/client-%07d.cert", randof (10000000));
     zcert_t *client_cert = zcert_new ();
     zcert_save_public (client_cert, filename);
     curve_client_t *client = curve_client_new (&client_cert);


### PR DESCRIPTION
I was trying to build libcurve package for ubuntu 12.04 and got this error:

gcc -std=gnu99 -DHAVE_CONFIG_H -I. -I../include  -pedantic -Werror -Wall -D_GNU_SOURCE -DLINUX -D_REENTRANT -D_THREAD_SAFE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -MT curve_selftest.o -MD -MP -MF .deps/curve_selftest.Tpo -c -o curve_selftest.o curve_selftest.c
mv -f .deps/curve_selftest.Tpo .deps/curve_selftest.Po
/bin/bash ../libtool --tag=CC   --mode=link gcc -std=gnu99  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security  -Wl,-Bsymbolic-functions -Wl,-z,relro -o curve_selftest curve_selftest.o libcurve.la -lsodium -lczmq -lzmq -lpthread
libtool: link: warning: library `/usr/lib/libzmq.la' was moved.
libtool: link: warning: library`/usr/lib/libzmq.la' was moved.
libtool: link: gcc -std=gnu99 -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Wl,-Bsymbolic-functions -Wl,-z -Wl,relro -o .libs/curve_selftest curve_selftest.o  ./.libs/libcurve.so /usr/lib/libsodium.so /usr/lib/libczmq.so /usr/lib/libzmq.so -lpthread -Wl,-rpath -Wl,/home/xpahos/pkgs/libcurve-4767fa6918/debian/libcurve/usr/lib
make  check-TESTS
make[1]: Entering directory `/place/home/xpahos/pkgs/libcurve-4767fa6918/src'
- curve_codec: OK
- curve_client: OK
- curve_server: �)ji�+�Z��tcp://127.0.0.1:9004
  /bin/bash: line 5:  2991 Segmentation fault      (core dumped) ${dir}$tst
  FAIL: curve_selftest
  ============================================
  1 of 1 test failed
  Please report to zeromq-dev@lists.zeromq.org
  ============================================
  make[1]: **\* [check-TESTS] Error 1
  make[1]: Leaving directory `/place/home/xpahos/pkgs/libcurve-4767fa6918/src'
  make: **\* [check-am] Error 2

After this small fix all tests has been passed
