### PR TITLE
Problem: client can't bind to 9004 in selftest

### DIFF
--- a/doc/curve_client.txt
+++ b/doc/curve_client.txt
@@ -95,7 +95,7 @@ EXAMPLE
     curve_client_set_metadata (client, "Client", "CURVEZMQ/curve_client");
     curve_client_set_metadata (client, "Identity", "E475DA11");
     curve_client_set_verbose (client, verbose);
-    curve_client_connect (client, "tcp://127.0.0.1:9000", zcert_public_key (server_cert));
+    curve_client_connect (client, "tcp://127.0.0.1:9004", zcert_public_key (server_cert));
 
     curve_client_sendstr (client, "Hello, World");
     char *reply = curve_client_recvstr (client);

--- a/doc/curve_codec.txt
+++ b/doc/curve_codec.txt
@@ -108,7 +108,7 @@ server_task (void *args)
     zauth_configure_curve (auth, "*", TESTDIR);
 
     void *router = zsocket_new (ctx, ZMQ_ROUTER);
-    int rc = zsocket_bind (router, "tcp://*:9000");
+    int rc = zsocket_bind (router, "tcp://127.0.0.1:9004");
     assert (rc != -1);
 
     zcert_t *cert = zcert_load (TESTDIR "/server.cert");
@@ -164,7 +164,7 @@ server_task (void *args)
     zctx_t *ctx = zctx_new ();
     assert (ctx);
     void *dealer = zsocket_new (ctx, ZMQ_DEALER);
-    int rc = zsocket_connect (dealer, "tcp://127.0.0.1:9000");
+    int rc = zsocket_connect (dealer, "tcp://127.0.0.1:9004");
     assert (rc != -1);
 
     //  We'll create two new certificates and save the client public 
@@ -174,7 +174,10 @@ server_task (void *args)
     zcert_save (server_cert, TESTDIR "/server.cert");
 
     zcert_t *client_cert = zcert_new ();
-    zcert_save_public (client_cert, TESTDIR "/client.cert");
+    char *filename = (char *) malloc (strlen (TESTDIR) + 21);
+    sprintf (filename, TESTDIR "/client-%07d.cert", randof (10000000));
+    zcert_save_public (client_cert, filename);
+    free (filename);
 
     //  We'll run the server as a background task, and the
     //  client in this foreground thread.

--- a/doc/curve_server.txt
+++ b/doc/curve_server.txt
@@ -103,7 +103,7 @@ EXAMPLE
 
     curve_server_t *server = curve_server_new (ctx, &server_cert);
     curve_server_set_verbose (server, verbose);
-    curve_server_bind (server, "tcp://*:9000");
+    curve_server_bind (server, "tcp://127.0.0.1:9004");
     
     while (live_clients > 0) {
         zmsg_t *msg = curve_server_recv (server);
@@ -117,7 +117,7 @@ EXAMPLE
     zcert_t *unknown = zcert_new ();
     curve_client_t *client = curve_client_new (&unknown);
     curve_client_set_verbose (client, true);
-    curve_client_connect (client, "tcp://127.0.0.1:9000", bad_server_key);
+    curve_client_connect (client, "tcp://127.0.0.1:9004", bad_server_key);
     curve_client_sendstr (client, "Hello, World");
 
     //  Expect no reply after 250msec

--- a/src/curve_client.c
+++ b/src/curve_client.c
@@ -453,7 +453,7 @@ server_task (void *args)
     zauth_configure_curve (auth, "*", TESTDIR);
 
     void *router = zsocket_new (ctx, ZMQ_ROUTER);
-    int rc = zsocket_bind (router, "tcp://127.0.0.1:9004");
+    int rc = zsocket_bind (router, "tcp://127.0.0.1:9005");
     assert (rc != -1);
 
     zcert_t *server_cert = zcert_load (TESTDIR "/server.cert");
@@ -530,7 +530,7 @@ curve_client_test (bool verbose)
     curve_client_set_metadata (client, "Client", "CURVEZMQ/curve_client");
     curve_client_set_metadata (client, "Identity", "E475DA11");
     curve_client_set_verbose (client, verbose);
-    curve_client_connect (client, "tcp://127.0.0.1:9004", zcert_public_key (server_cert));
+    curve_client_connect (client, "tcp://127.0.0.1:9005", zcert_public_key (server_cert));
 
     curve_client_sendstr (client, "Hello, World");
     char *reply = curve_client_recvstr (client);

--- a/src/curve_server.c
+++ b/src/curve_server.c
@@ -619,7 +619,7 @@ client_task (void *args)
 
     zcert_t *server_cert = zcert_load (TESTDIR "/server.cert");
     assert (server_cert);
-    curve_client_connect (client, "tcp://127.0.0.1:9004", zcert_public_key (server_cert));
+    curve_client_connect (client, "tcp://127.0.0.1:9006", zcert_public_key (server_cert));
     zcert_destroy (&server_cert);
 
     curve_client_sendstr (client, "Hello, World");
@@ -698,7 +698,7 @@ curve_server_test (bool verbose)
 
     curve_server_t *server = curve_server_new (ctx, &server_cert);
     curve_server_set_verbose (server, verbose);
-    curve_server_bind (server, "tcp://127.0.0.1:9004");
+    curve_server_bind (server, "tcp://127.0.0.1:9006");
     
     while (live_clients > 0) {
         zmsg_t *msg = curve_server_recv (server);
@@ -712,7 +712,7 @@ curve_server_test (bool verbose)
     zcert_t *unknown = zcert_new ();
     curve_client_t *client = curve_client_new (&unknown);
     curve_client_set_verbose (client, true);
-    curve_client_connect (client, "tcp://127.0.0.1:9004", bad_server_key);
+    curve_client_connect (client, "tcp://127.0.0.1:9006", bad_server_key);
     curve_client_sendstr (client, "Hello, World");
 
     //  Expect no reply after 250msec


### PR DESCRIPTION
Address is being freed by previous test cases. Properly, libcurve
should migrate to CZMQ v3 API.

Solution: use different port for each test case.
